### PR TITLE
feat: Add alternative HTTP port flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Flags:
   -h, --help                    help for booty
       --httpPort int            Port to use for the HTTP server (default 8080)
       --serverIP string         IP address that clients can connect to (default "127.0.0.1")
+      --serverHttpPort int      Port to use for the client HTTP connection (default "80)
       --joinString string       The kubeadm join string to use to auto-join to a K8s cluster (kubeadm join 192.168.1.10:6443 --token TOKEN --discovery-token-ca-cert-hash sha256:SHA_HASH (default "")
       --updateSchedule string   Cron schedule to use for cleaning up cache files (default "* */1 * * *")
 ```

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,15 +20,16 @@ var Cmd = &cobra.Command{
 }
 
 var args struct {
-	debug        bool
-	dataDir      string
-	maxCacheAge  int
-	cronSchedule string
-	httpPort     int
-	architecture string
-	serverIP     string
-	joinString   string
-	channel      string
+	debug        	bool
+	dataDir      	string
+	maxCacheAge  	int
+	cronSchedule 	string
+	httpPort     	int
+	architecture 	string
+	serverIP     	string
+	serverHttpPort 	int
+	joinString   	string
+	channel      	string
 }
 
 func init() {
@@ -79,6 +80,12 @@ func init() {
 		"serverIP",
 		"127.0.0.1",
 		"IP address that clients can connect to",
+	)
+	flags.IntVar(
+		&args.serverHttpPort,
+		"serverHttpPort",
+		80,
+		"Alternative HTTP port to use for clients",
 	)
 
 	flags.StringVar(

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,7 @@ const (
 	DataDir        = "dataDir"
 	FlatcarURL     = "flatcarURL"
 	ServerIP       = "serverIP"
+	ServerHttpPort = "serverHttpPort"
 	JoinString     = "joinString"
 	Updating       = "updating"
 )

--- a/pkg/tftp/tftp.go
+++ b/pkg/tftp/tftp.go
@@ -17,7 +17,12 @@ import (
 func readHandler(filename string, rf io.ReaderFrom) error {
 	log.Printf("TFTP Get: %s\n", filename)
 	if filename == "pxelinux.cfg/default" {
-		r := strings.NewReader(fmt.Sprintf(PXEConfigContents, viper.GetString(config.ServerIP)))
+		urlHost = viper.GetString(config.ServerIP)
+		hostPort = viper.GetInt(config.ServerHttpPort)
+		if hostPort != 80 {
+			urlHost = fmt.Sprintf("%s:%d", urlHost, hostPort)
+		}
+		r := strings.NewReader(fmt.Sprintf(PXEConfigContents, urlHost))
 		n, err := rf.ReadFrom(r)
 		if err != nil {
 			log.Printf("Error reading PXE config: %v\n", err)

--- a/pkg/tftp/tftp.go
+++ b/pkg/tftp/tftp.go
@@ -17,7 +17,12 @@ import (
 func readHandler(filename string, rf io.ReaderFrom) error {
 	log.Printf("TFTP Get: %s\n", filename)
 	if filename == "pxelinux.cfg/default" {
-		r := strings.NewReader(fmt.Sprintf(PXEConfigContents, viper.GetString(config.ServerIP)))
+		urlHost := viper.GetString(config.ServerIP)
+		hostPort := viper.GetInt(config.ServerHttpPort)
+		if hostPort != 80 {
+			urlHost = fmt.Sprintf("%s:%d", urlHost, hostPort)
+		}
+		r := strings.NewReader(fmt.Sprintf(PXEConfigContents, urlHost))
 		n, err := rf.ReadFrom(r)
 		if err != nil {
 			log.Printf("Error reading PXE config: %v\n", err)


### PR DESCRIPTION
Closes #1

Adds the `serverHttpPort` flag to allow clients to connect to the HTTP service when ran on a non-standard port (i.e. 8080).